### PR TITLE
Handle block loading error

### DIFF
--- a/extensions/order-management-block/src/BlockExtension.tsx
+++ b/extensions/order-management-block/src/BlockExtension.tsx
@@ -31,7 +31,7 @@ interface ProductInfo {
 }
 
 function App() {
-  const { data, query } = useApi(TARGET);
+  const { data, query } = useApi();
   const [products, setProducts] = useState<ProductInfo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isProcessing, setIsProcessing] = useState(false);


### PR DESCRIPTION
Fixes block loading error by calling `useApi()` without arguments.

The `useApi` hook in Shopify Admin UI extensions should be called without arguments. Passing `TARGET` was causing a runtime initialization error, leading to the "There was an issue loading this block" message.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c37539b-6e9a-492e-8188-1bcf4d3e8f15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c37539b-6e9a-492e-8188-1bcf4d3e8f15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

